### PR TITLE
Fix: context class getters + core mapping fix

### DIFF
--- a/include/PPN-microbench/context.hpp
+++ b/include/PPN-microbench/context.hpp
@@ -45,6 +45,19 @@ class Context {
     void operator=(Context const &) = delete;
     ~Context();
 
+    const std::string &getCpuArchi() const { return cpuArchi; }
+    const size_t &getWordSize() const { return wordSize; }
+    const size_t &getSockets() const { return sockets; }
+    const size_t &getCpus() const { return cpus; }
+    const size_t &getThreads() const { return threads; }
+    const std::vector<size_t> getThreadMapping() const { return threadMapping; }
+    const std::set<std::string> &getSIMD() const { return simd; }
+    const size_t &getMemory() const { return memory; }
+    const size_t &getl1d() const { return l1d; }
+    const size_t &getl1i() const { return l1i; }
+    const size_t &getl2() const { return l2; }
+    const size_t &getl3() const { return l3; }
+
     json getJson();
 };
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -8,5 +8,5 @@
 
 int main() {
     Flops f(10);
-    f.context.getInstance().getJson();
+    std::cout << f.context.getInstance().getJson().dump(4) << std::endl;
 }

--- a/src/PPN-microbench/context.cpp
+++ b/src/PPN-microbench/context.cpp
@@ -101,8 +101,8 @@ void Context::cpuInfo() {
             // only add the current core to the mapping if it hasn't appeared
             // before.
             if (mappedCores.find(proc) == mappedCores.end()) {
-                threadMapping.push_back(proc);
-                mappedCores.emplace(currProc);
+                threadMapping.push_back(currProc);
+                mappedCores.emplace(proc);
             }
         }
 
@@ -113,6 +113,15 @@ void Context::cpuInfo() {
                 mappedCores.clear();
                 sockets = sockCout;
             }
+        }
+    }
+
+    // ARM /proc/cpuinfo has way less information about cpu cores
+    // we have to manuall set the mapping
+    if (cpuArchi == "ARM") {
+        cpus = threads;
+        for (size_t i = 0; i < cpus; i++) {
+            threadMapping.push_back(i);
         }
     }
 


### PR DESCRIPTION
Resolves #16

Added getters for context attributes.

Fixed thread->core mapping on some cpus. also changed the behaviors on ARM chips, `/proc/cpuinfo` behaves very differently on arm cpus (no `core id` field on processors). By default every thread will get mapped now. 