### PR TITLE
Memory latency

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,8 @@ Language: Cpp
 # Indentation style
 IndentWidth: 4
 TabWidth: 4
+# Indent pre-processor directives before the hash.
+IndentPPDirectives: AfterHash
 
 # opening braces style (same line)
 BraceWrapping:

--- a/include/PPN-microbench/memory.hpp
+++ b/include/PPN-microbench/memory.hpp
@@ -1,0 +1,44 @@
+#ifndef PPN_MICROBENCH_CACHE_HPP
+#define PPN_MICROBENCH_CACHE_HPP
+
+// Include necessary headers
+#include <PPN-microbench/constants.hpp>
+#include <PPN-microbench/microbench.hpp>
+#include <nlohmann/json.hpp>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <numeric>
+#include <vector>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+
+// Alias for nlohmann::ordered_json
+using json = nlohmann::ordered_json;
+
+// Memory class inherits from Microbench
+class Memory : public Microbench {
+  private:
+    // Vectors to store memory sizes and times
+    std::vector<u64> mem_sizes;
+    std::vector<u64> mem_times;
+
+    // Function to execute the benchmark, overrides the base class method
+    void executeBench() override;
+
+  public:
+    // Constructor to initialize the Memory object with a name and number of iterations
+    Memory(std::string name, int nbIterations);
+    
+    // Destructor
+    ~Memory();
+
+    // Function to run the benchmark, overrides the base class method
+    void run() override;
+    
+    // Function to get the results in JSON format, overrides the base class method
+    json getJson() override;
+};
+
+#endif 

--- a/main/conductor_main.cpp
+++ b/main/conductor_main.cpp
@@ -1,13 +1,12 @@
 #include <PPN-microbench/conductor.hpp>
-#include <PPN-microbench/ops/flops.hpp>
-#include <PPN-microbench/ops/iops.hpp>
+#include <PPN-microbench/memory.hpp>
+
 
 int main() {
 
     Conductor conductor;
 
-    conductor.addBench(new Flops(5))
-        .addBench(new Iops(5))
+    conductor.addBench(new Memory("Memory",1))
         .setOutputFile("../tmp/out.json")
         .run()
         .save()

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2,11 +2,15 @@
 #include <PPN-microbench/microbench.hpp>
 #include <PPN-microbench/ops/flops.hpp>
 #include <PPN-microbench/ops/iops.hpp>
+#include <PPN-microbench/memory.hpp>
 
 #include <nlohmann/json.hpp>
 #include <vector>
 
 int main() {
-    Flops f(10);
-    f.context.getInstance().getJson();
+    Memory memoryBenchmark("Memory Latency Benchmark", 1);
+    memoryBenchmark.run();
+    json results = memoryBenchmark.getJson();
+    std::cout << results.dump(4) << std::endl;
+    return 0;
 }

--- a/src/PPN-microbench/CMakeLists.txt
+++ b/src/PPN-microbench/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(PPN-microbench STATIC)
 
 target_sources(PPN-microbench PRIVATE microbench.cpp context.cpp conductor.cpp)
 target_sources(PPN-microbench PRIVATE ops/abstract_ops.cpp ops/flops.cpp ops/iops.cpp)
+target_sources(PPN-microbench PRIVATE memory.cpp)
 
 target_sources(
     PPN-microbench
@@ -16,6 +17,8 @@ target_sources(
         FILES ${PROJECT_SOURCE_DIR}/include/PPN-microbench/ops/abstract_ops.hpp
         FILES ${PROJECT_SOURCE_DIR}/include/PPN-microbench/ops/flops.hpp
         FILES ${PROJECT_SOURCE_DIR}/include/PPN-microbench/ops/iops.hpp
+        FILES ${PROJECT_SOURCE_DIR}/include/PPN-microbench/constants.hpp
+        FILES ${PROJECT_SOURCE_DIR}/include/PPN-microbench/memory.hpp
 )
 
 set_target_properties(PPN-microbench PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
@@ -23,3 +26,4 @@ target_link_libraries(PPN-microbench PRIVATE nlohmann_json::nlohmann_json)
 set(CMAKE_CXX_FLAGS "-O3")
 set(CMAKE_CXX_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS "-Wextra")
+set(CMAKE_CXX_FLAGS "-g")

--- a/src/PPN-microbench/memory.cpp
+++ b/src/PPN-microbench/memory.cpp
@@ -1,0 +1,81 @@
+#include <PPN-microbench/memory.hpp>
+
+
+// Function to generate a random index within a given threshold
+inline u64 random_index(u64 threshold) { return rand() % threshold; }
+
+// Function to measure cache/memory latency using pointer chasing
+double measure_latency(u64 size, u64 nbIterations) {
+    std::vector<void *> memblock(size);
+
+    // Initialize the memory block with pointers to itself
+    for (u64 i = 0; i < size; ++i) {
+        memblock[i] = &memblock[i];
+    }
+
+    // Shuffle the pointers to create a random access pattern
+    for (u64 i = size - 1; i > 0; --i) {
+        u64 j = random_index(i + 1);
+        std::swap(memblock[i], memblock[j]);
+    }
+
+    double total_latency = 0.0;
+
+    // Perform the latency measurement 10 times for better accuracy
+    for (int run = 0; run < 10; ++run) {
+        void *p = memblock[0];
+        auto start = std::chrono::high_resolution_clock::now();
+
+        // Pointer chasing loop
+        for (u64 i = 0; i < nbIterations; ++i) {
+            p = *(void **)p;
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double, std::nano> elapsed = end - start;
+
+        // Accumulate the latency
+        total_latency += elapsed.count() / nbIterations;
+    }
+
+    // Calculate the average latency over 10 runs
+    return total_latency / 10.0;
+}
+
+// Constructor
+Memory::Memory(std::string name, int nbIterations)
+    : Microbench(name, nbIterations) {
+    srand(time(nullptr));
+}
+
+// Destructor
+Memory::~Memory() {}
+
+// Execute the benchmark
+void Memory::executeBench() {
+    // Define the sizes to test (in B)
+    for (u64 size = 512; size <= 10e8 / sizeof(void *); size *= 2) {
+        mem_sizes.push_back(size);
+    }
+    u64 nbIterations = 1000000;
+
+    for (u64 size_B : mem_sizes) {
+        // u64 size = size_B / sizeof(void *);
+        double latency = measure_latency(size_B, nbIterations);
+        mem_times.push_back(latency);
+    }
+}
+
+// Run the benchmark
+void Memory::run() { executeBench(); }
+
+// Get the results in JSON format
+json Memory::getJson() {
+    json result1, result2, result;
+    for (size_t i = 0; i < mem_sizes.size(); ++i) {
+        result1["Memory Size (B)"].push_back(mem_sizes[i]);
+        result2["Latency (ns)"].push_back(mem_times[i]);
+        result["Memory Size (B), Latency (ns)"] = {result1, result2};
+    }
+    return result;
+}


### PR DESCRIPTION
This pull request introduces a new memory benchmarking feature to the PPN-microbench project. The most important changes include the addition of a new `Memory` class for measuring memory latency, updates to the main application files to incorporate this new benchmark, and modifications to the build configuration to include the new files.

### New Memory Benchmark Feature:

* [`include/PPN-microbench/memory.hpp`]
 Added a new `Memory` class that inherits from `Microbench` to measure memory latency. This class includes methods for running the benchmark and returning results in JSON format.
* [`src/PPN-microbench/memory.cpp`]
Implemented the `Memory` class, including methods for measuring memory latency using pointer chasing, running the benchmark, and formatting the results as JSON.

### Application Updates:

* [`main/conductor_main.cpp`]
Updated to include the new `Memory` benchmark in the `Conductor` class, replacing the previous `Flops` and `Iops` benchmarks.
* [`main/main.cpp`]
Modified to run the new `Memory` benchmark and print the results in JSON format.

### Build Configuration:

* [`src/PPN-microbench/CMakeLists.txt`]
Updated to include the new `memory.cpp` source file and `memory.hpp` header file in the build process. 

### Code Formatting:

* [`.clang-format`]
 Added a rule to indent pre-processor directives after the hash.