### PR TITLE
Matrix Multiplication microbenchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,12 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cli11)
 
 FetchContent_Declare(
-    openblas
-    GIT_REPOSITORY https://github.com/OpenMathLib/OpenBLAS.git
-    GIT_TAG v0.3.29
+    Eigen3
+    GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+    GIT_TAG 3.4.0
 )
 
-FetchContent_MakeAvailable(openblas)
+FetchContent_MakeAvailable(Eigen3)
 
 add_subdirectory(src/PPN-microbench)
 add_subdirectory(main)
@@ -55,7 +55,7 @@ endif()
 # Debug or not debug, that is the question
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
-    target_compile_options(PPN-microbench PRIVATE -Wall -Wextra -g -lopenblas)
+    target_compile_options(PPN-microbench PRIVATE -Wall -Wextra -g)
 endif()
 
 target_compile_features(PPN-microbench PRIVATE cxx_std_20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,14 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(cli11)
 
+FetchContent_Declare(
+    openblas
+    GIT_REPOSITORY https://github.com/OpenMathLib/OpenBLAS.git
+    GIT_TAG v0.3.29
+)
+
+FetchContent_MakeAvailable(openblas)
+
 add_subdirectory(src/PPN-microbench)
 add_subdirectory(main)
 
@@ -47,7 +55,7 @@ endif()
 # Debug or not debug, that is the question
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
-    target_compile_options(PPN-microbench PRIVATE -Wall -Wextra -g)
+    target_compile_options(PPN-microbench PRIVATE -Wall -Wextra -g -lopenblas)
 endif()
 
 target_compile_features(PPN-microbench PRIVATE cxx_std_20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(Eigen3)
+
+FetchContent_Declare(
     OpenCL-Headers
     GIT_REPOSITORY  https://github.com/KhronosGroup/OpenCL-Headers.git
     GIT_TAG         main

--- a/include/PPN-microbench/context.hpp
+++ b/include/PPN-microbench/context.hpp
@@ -10,6 +10,10 @@
 #include <string>
 #include <unistd.h>
 #include <vector>
+#include <spdlog/spdlog.h>
+#include <stdlib.h>
+#include <iostream>
+#include <sstream>
 
 using json = nlohmann::ordered_json;
 
@@ -17,16 +21,19 @@ class Context {
   private:
     std::string cpuArchi;
     size_t wordSize;
-    // Amound of sockets on the node
+    // Amount of sockets on the node
     size_t sockets;
-    // Amound of physical cores on the node
+    // Amount of physical cores on the node
     size_t cpus;
-    // Amound of virtural core on the node
+    // Amount of virtural core on the node
     size_t threads;
     // Mapping of the virtual cores to the physical ones
     std::vector<size_t> threadMapping;
+    //Max cpu frequency
+    size_t max_mhz;
     std::set<std::string> simd;
     size_t memory;
+    
     // cache size is PER CORE
     size_t l1d;
     size_t l1i;
@@ -50,6 +57,7 @@ class Context {
     const size_t &getCpus() const { return cpus; }
     const size_t &getThreads() const { return threads; }
     const std::vector<size_t> getThreadMapping() const { return threadMapping; }
+    const size_t &getMax_mhz() const {return max_mhz; }
     const std::set<std::string> &getSIMD() const { return simd; }
     const size_t &getMemory() const { return memory; }
     const size_t &getl1d() const { return l1d; }

--- a/include/PPN-microbench/driver.hpp
+++ b/include/PPN-microbench/driver.hpp
@@ -4,6 +4,7 @@
 #include <PPN-microbench/core_to_core_latency.hpp>
 #include <PPN-microbench/microbench.hpp>
 #include <PPN-microbench/ops.hpp>
+#include <PPN-microbench/matrix_bench.hpp>
 
 #include <CLI/CLI.hpp>
 

--- a/include/PPN-microbench/matrix_bench.hpp
+++ b/include/PPN-microbench/matrix_bench.hpp
@@ -1,0 +1,39 @@
+#ifndef PPN_MICROBENCH_MATRIX_HPP
+#define PPN_MICROBENCH_MATRIX_HPP
+
+// Include necessary headers
+
+#include <PPN-microbench/microbench.hpp>
+#include <nlohmann/json.hpp>
+#include <iostream>
+#include <chrono>
+#include <cmath>
+#include <vector>
+#include<cblas.h>
+
+
+// Matrix class inherits from Microbench
+class Matrix_bench : public Microbench {
+  private:
+    
+    std::vector<uint64_t> mem_sizes; // Vector to store memory sizes
+    std::vector<double> time_seconds; // Vector to store time in seconds
+    std::vector<double> Gflops; // Vector to store floating point operations
+    
+
+  public:
+    // Constructor
+    Matrix_bench();
+
+    // Destructor
+    ~Matrix_bench();
+
+    // Function to run the benchmark, overrides the base class method
+    void run() override;
+
+    // Function to get the results in JSON format, overrides the base class
+    // method
+    json getJson() override;
+};
+
+#endif

--- a/include/PPN-microbench/matrix_bench.hpp
+++ b/include/PPN-microbench/matrix_bench.hpp
@@ -9,7 +9,7 @@
 #include <chrono>
 #include <cmath>
 #include <vector>
-#include<cblas.h>
+#include <cblas.h>
 
 
 // Matrix class inherits from Microbench

--- a/include/PPN-microbench/matrix_bench.hpp
+++ b/include/PPN-microbench/matrix_bench.hpp
@@ -16,7 +16,7 @@
 class Matrix_bench : public Microbench {
   private:
     
-    std::vector<uint64_t> mem_sizes; // Vector to store memory sizes
+    std::vector<uint64_t> N_sizes; // Vector to store memory sizes
     std::vector<double> time_seconds; // Vector to store time in seconds
     std::vector<double> Gflops; // Vector to store floating point operations
     

--- a/include/PPN-microbench/matrix_bench.hpp
+++ b/include/PPN-microbench/matrix_bench.hpp
@@ -19,7 +19,8 @@ class Matrix_bench : public Microbench {
     std::vector<uint64_t> N_sizes; // Vector to store memory sizes
     std::vector<double> time_seconds; // Vector to store time in seconds
     std::vector<double> Gflops; // Vector to store floating point operations
-    
+    std::vector<double> gflops_per_run; // Store Gflops for each run to calculate error
+    std::vector<double> error_Gflops; // Vector to store error in Gflops
 
   public:
     // Constructor

--- a/include/PPN-microbench/matrix_bench.hpp
+++ b/include/PPN-microbench/matrix_bench.hpp
@@ -9,7 +9,7 @@
 #include <chrono>
 #include <cmath>
 #include <vector>
-#include <cblas.h>
+#include <Eigen/Dense>
 
 
 // Matrix class inherits from Microbench

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(main)
 target_sources(main PRIVATE main.cpp)
-target_link_libraries(main PPN-microbench nlohmann_json::nlohmann_json spdlog::spdlog CLI11::CLI11 openblas)
+target_link_libraries(main PPN-microbench nlohmann_json::nlohmann_json spdlog::spdlog CLI11::CLI11 Eigen3::Eigen)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(main)
 target_sources(main PRIVATE main.cpp)
-target_link_libraries(main PPN-microbench nlohmann_json::nlohmann_json spdlog::spdlog CLI11::CLI11)
+target_link_libraries(main PPN-microbench nlohmann_json::nlohmann_json spdlog::spdlog CLI11::CLI11 openblas)

--- a/report/elements/base.py
+++ b/report/elements/base.py
@@ -24,7 +24,8 @@ class Report(AbstractElement):
             "OPS" : Ops,
             "CPU Frequency": CpuFrequency,
             "Core To Core Latency": CoreToCoreLatency,
-            "Cache Latency" : Cache_Latency
+            "Cache Latency" : Cache_Latency,
+            "Matrix Multiplication" : Matrix_Bench
         }
 
         self.generate()

--- a/report/elements/base.py
+++ b/report/elements/base.py
@@ -25,7 +25,7 @@ class Report(AbstractElement):
             "CPU Frequency": CpuFrequency,
             "Core To Core Latency": CoreToCoreLatency,
             "Cache Latency" : Cache_Latency,
-            "Matrix Multiplication" : Matrix_Bench
+            "Matrix Multiplication" : MatrixBench
         }
 
         self.generate()

--- a/report/elements/bench/__init__.py
+++ b/report/elements/bench/__init__.py
@@ -2,3 +2,4 @@ from elements.bench.ops import Ops
 from elements.bench.cpu_frequency import CpuFrequency
 from elements.bench.core_to_core_latency import CoreToCoreLatency
 from elements.bench.cache_latency import Cache_Latency
+from elements.bench.matrix_bench import Matrix_Bench

--- a/report/elements/bench/__init__.py
+++ b/report/elements/bench/__init__.py
@@ -2,4 +2,4 @@ from elements.bench.ops import Ops
 from elements.bench.cpu_frequency import CpuFrequency
 from elements.bench.core_to_core_latency import CoreToCoreLatency
 from elements.bench.cache_latency import Cache_Latency
-from elements.bench.matrix_bench import Matrix_Bench
+from elements.bench.matrix_bench import MatrixBench

--- a/report/elements/bench/cache_latency.py
+++ b/report/elements/bench/cache_latency.py
@@ -62,7 +62,7 @@ class Cache_Latency(AbstractBench):
             color='cyan',
             alpha=0.2, # Adjust transparency
             edgecolor='blue',
-            label='Error Band (±1 std dev)',
+            label='Error Band (std dev)',
             linewidth=2  # Increase line thickness
         )
 

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -32,7 +32,7 @@ class Matrix_Bench(AbstractBench):
         plt.figure(figsize=(10, 6))
         plt.plot(sizes, gflops, marker='o', color='blue', label="GFLOPS (per size)")
         plt.ylim(0)
-    
+            
         # Add lines for max and average GFLOPS
         plt.axhline(summary["gflops_max"], color='red', linestyle='--', label=f"Max GFLOPS: {summary['gflops_max']:.1f}")
         plt.axhline(summary["gflops_avg"], color='green', linestyle='--', label=f"Average GFLOPS: {summary['gflops_avg']:.1f}")
@@ -57,7 +57,7 @@ class Matrix_Bench(AbstractBench):
         )        
 
         # Format the plot
-        plt.title("Benchmark DGEMM - Performance (GFLOPS)")
+        plt.title("Matrix Multiplication performance (GFLOPS)")
         plt.xlabel("Matrix Size (N x N)")
         plt.ylabel("GFLOPS")
         plt.grid(True)

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -7,61 +7,50 @@ import os
 
 class Matrix_Bench(AbstractBench):
     def __init__(self, obj, bench_obj):
-        self.obj = obj
+        self.obj = obj  # Le JSON complet
         self.bench_obj = bench_obj
 
     def to_html(self):
         self.gen_images()
         wd = os.getcwd()
-        header = "<h2 id='Matrix_Bench'>Matrix Bench</h2>"
+        header = "<h2 id='Matrix_Bench'>Matrix Multipication</h2>"
         imgs = f"<img src='{wd}/out/matrix_benchmark_plot.png'/>"
-        p = "<p>Matrix benchmark results for DGEMM.</p>"
+        p = "<p>This benchmark evaluates the performance of dense matrix multiplication using Eigen. Below is the GFLOPS achieved for various matrix sizes.</p>"
         return header + imgs + p
 
     def gen_images(self):
-        # Load data
-        data = self.obj
-        sizes = np.array(data["sizes"])
-        gflops = np.array(data["gflops"])
-        
-        
+        # Accès aux données depuis self.obj
+        bench_data = self.obj["data"][0]
+        results = bench_data["results"]
+        summary = bench_data["summary"]
 
-# Load JSON data
-with open("matrix_dgemm_results.json", "r") as f:
-    data = json.load(f)
+        sizes = [entry["size"] for entry in results]
+        gflops = [entry["Gflops"] for entry in results]
 
-results = data["results"]
-summary = data["summary"]
+        # Création du graphique
+        plt.figure(figsize=(10, 6))
+        plt.plot(sizes, gflops, marker='o', color='blue', label="GFLOPS (par taille)")
 
-sizes = [entry["size"] for entry in results]
-gflops = [entry["gflops"] for entry in results]
+        # Ligne de max et moyenne
+        plt.axhline(summary["gflops_max"], color='red', linestyle='--', label=f"Max GFLOPS: {summary['gflops_max']:.2f}")
+        plt.axhline(summary["gflops_avg"], color='green', linestyle='--', label=f"Moyenne GFLOPS: {summary['gflops_avg']:.2f}")
 
-# Plot the results
-plt.figure(figsize=(10, 6))
-plt.plot(sizes, gflops, marker='o', label="GFLOPS (by size)")
-plt.axhline(summary["gflops_max"], color='r', linestyle='--', label=f"Max: {summary['gflops_max']:.2f} GFLOPS")
-plt.axhline(summary["gflops_avg"], color='g', linestyle='--', label=f"Average: {summary['gflops_avg']:.2f} GFLOPS")
+        # Annotations sur les points
+        for x, y in zip(sizes, gflops):
+            plt.text(x, y + 0.5, f"{y:.1f}", ha='center', fontsize=9)
 
-# Formatting
-plt.title("DGEMM Benchmark - Performance in GFLOPS")
-plt.xlabel("Matrix size (N x N)")
-plt.ylabel("GFLOPS")
-plt.grid(True)
-plt.legend()
-plt.tight_layout()
+        # Mise en forme du graphique
+        plt.title("Benchmark DGEMM - Performance (GFLOPS)")
+        plt.xlabel("Taille des matrices (N x N)")
+        plt.ylabel("GFLOPS")
+        plt.grid(True)
+        plt.legend()
+        plt.tight_layout()
 
-# Save the plot
-os.makedirs("out", exist_ok=True)
-plt.savefig("out/matrix_benchmark_plot.png")
-plt.close()
+        # Création du dossier de sortie et sauvegarde
+        os.makedirs("out", exist_ok=True)
+        plt.savefig("out/matrix_benchmark_plot.png", dpi=300)
+        plt.close()
 
-# Show the plot        
-plt.show()
-
-def get_index(self):
-    return {
-        "title": "Matrix Bench",
-        "id": "Matrix_Bench",
-        "description": "Matrix benchmark results for DGEMM.",
-        "icon": "matrix_bench_icon.png"
-    }
+    def get_index(self):
+        return "<li><a href='#Matrix_Bench'>Matrix Multiplication DGEMM</a></li>"

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -2,10 +2,8 @@ from elements.bench.base import AbstractBench
 
 import matplotlib.pyplot as plt
 import os
-import subprocess
-import sysconfig
 
-class Matrix_Bench(AbstractBench):
+class MatrixBench(AbstractBench):
     def __init__(self, obj, bench_obj):
         self.obj = obj  # The complete JSON object
         self.bench_obj = bench_obj  # The specific benchmark object
@@ -129,6 +127,7 @@ class Matrix_Bench(AbstractBench):
 
         return rpeak, flops_per_cycle_per_core, num_cores, clock_ghz
 
+    
     def efficiency(self):
         data = self.obj
         gflops_max = self.bench_obj["summary"]["gflops_max"]
@@ -146,4 +145,4 @@ class Matrix_Bench(AbstractBench):
         return "<li><a href='#Matrix_Bench'>Matrix Multiplication DGEMM</a></li>"
 
 
-# faire la perf crête théorique : Rpeak = # of FP64 units (per core) * # of cores * max clock rate
+

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -46,16 +46,26 @@ class Matrix_Bench(AbstractBench):
         sizes = [entry["size"] for entry in results]
         gflops = [entry["Gflops"] for entry in results]
 
+        # define y axis superior limit
+
+        rpeak, _, _, _ = self.compute_rpeak()
+
+        if rpeak != 0:
+            y_max = max(rpeak, summary["gflops_max"]) * 1.1
+        else:
+            y_max = summary["gflops_max"] * 1.1
+
         # Create the plot
         plt.figure(figsize=(10, 6))
         plt.plot(sizes, gflops, marker='o', color='blue', label="GFLOPS (per size)")
-        plt.ylim(0, self.compute_rpeak()[0] * 1.1)
-        plt.axhline(summary["gflops_max"], color='red', linestyle='--', label=f"RMax : {summary['gflops_max']:.1f} GFLOPS")
-        plt.axhline(self.compute_rpeak()[0], color='orange', linestyle='--', label=f"Rpeak: {self.compute_rpeak()[0]:.1f} GFLOPS")
+        plt.ylim(0, y_max)
+        plt.axhline(summary["gflops_max"], color='red', linestyle='--', label=f"RMax : {summary['gflops_max']:.2f} GFLOPS")
+        if rpeak != 0:
+            plt.axhline(self.compute_rpeak()[0], color='orange', linestyle='--', label=f"Rpeak: {self.compute_rpeak()[0]:.2f} GFLOPS")
 
         error_Gflops = self.bench_obj["summary"].get("error_Gflops", [0.05 * g for g in gflops])
         for x, y, e in zip(sizes, gflops, error_Gflops):
-            plt.text(x, y + e + 0.5, f"{y:.1f}", ha='center', fontsize=9)
+            plt.text(x, y + e + 0.5, f"{y:.2f}", ha='center', fontsize=9)
 
         plt.fill_between(
             sizes,

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -7,50 +7,68 @@ import os
 
 class Matrix_Bench(AbstractBench):
     def __init__(self, obj, bench_obj):
-        self.obj = obj  # Le JSON complet
-        self.bench_obj = bench_obj
+        self.obj = obj  # The complete JSON object
+        self.bench_obj = bench_obj  # The specific benchmark object
 
     def to_html(self):
+        # Generate the plot and return the HTML content
         self.gen_images()
         wd = os.getcwd()
-        header = "<h2 id='Matrix_Bench'>Matrix Multipication</h2>"
+        header = "<h2 id='Matrix_Bench'>Matrix Multiplication DGEMM</h2>"
         imgs = f"<img src='{wd}/out/matrix_benchmark_plot.png'/>"
         p = "<p>This benchmark evaluates the performance of dense matrix multiplication using Eigen. Below is the GFLOPS achieved for various matrix sizes.</p>"
         return header + imgs + p
 
     def gen_images(self):
-        # Accès aux données depuis self.obj
-        bench_data = self.obj["data"][0]
-        results = bench_data["results"]
-        summary = bench_data["summary"]
-
+        # Access data directly from self.obj
+        # self.bench_obj is a dictionary containing the benchmark results
+        results = self.bench_obj["results"]
+        summary = self.bench_obj["summary"]
+    
         sizes = [entry["size"] for entry in results]
         gflops = [entry["Gflops"] for entry in results]
-
-        # Création du graphique
+   
+        # Create the plot
         plt.figure(figsize=(10, 6))
-        plt.plot(sizes, gflops, marker='o', color='blue', label="GFLOPS (par taille)")
-
-        # Ligne de max et moyenne
-        plt.axhline(summary["gflops_max"], color='red', linestyle='--', label=f"Max GFLOPS: {summary['gflops_max']:.2f}")
-        plt.axhline(summary["gflops_avg"], color='green', linestyle='--', label=f"Moyenne GFLOPS: {summary['gflops_avg']:.2f}")
-
-        # Annotations sur les points
+        plt.plot(sizes, gflops, marker='o', color='blue', label="GFLOPS (per size)")
+        plt.ylim(0)
+    
+        # Add lines for max and average GFLOPS
+        plt.axhline(summary["gflops_max"], color='red', linestyle='--', label=f"Max GFLOPS: {summary['gflops_max']:.1f}")
+        plt.axhline(summary["gflops_avg"], color='green', linestyle='--', label=f"Average GFLOPS: {summary['gflops_avg']:.1f}")
+     
+        # Add annotations on the points
         for x, y in zip(sizes, gflops):
             plt.text(x, y + 0.5, f"{y:.1f}", ha='center', fontsize=9)
+        
+        # Calculate the error (e.g., ±5% of GFLOPS values)
+        error = [0.05 * g for g in gflops]
 
-        # Mise en forme du graphique
+        # Plot the error band
+        plt.fill_between(
+            sizes,
+            [g - e for g, e in zip(gflops, error)],  # Lower values
+            [g + e for g, e in zip(gflops, error)],  # Upper values
+            color='cyan',
+            alpha=0.2,
+            label='Error Band (±5%)',
+            edgecolor='blue',
+            linewidth=2,  
+        )        
+
+        # Format the plot
         plt.title("Benchmark DGEMM - Performance (GFLOPS)")
-        plt.xlabel("Taille des matrices (N x N)")
+        plt.xlabel("Matrix Size (N x N)")
         plt.ylabel("GFLOPS")
         plt.grid(True)
         plt.legend()
         plt.tight_layout()
-
-        # Création du dossier de sortie et sauvegarde
+    
+        # Create the output directory and save the plot
         os.makedirs("out", exist_ok=True)
         plt.savefig("out/matrix_benchmark_plot.png", dpi=300)
         plt.close()
 
     def get_index(self):
+        # Return the index entry for the Matrix Multiplication section
         return "<li><a href='#Matrix_Bench'>Matrix Multiplication DGEMM</a></li>"

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -16,7 +16,7 @@ class MatrixBench(AbstractBench):
         imgs = f"<img src='{wd}/out/matrix_benchmark_plot.png'/>"
         p = """
         <p>This benchmark evaluates the performance of dense matrix multiplication using Eigen. Below is the GFLOPS achieved for various matrix sizes.</p>
-        <p>Note: For the calculation of Rpeak, we assume 2 SIMD_ISA_NAME instructions/cycle/core, i.e. FLOP/cycle/core. If neither Rpeak nor efficiency is available, it indicates that the 'max MHz' value necessary to calculate the Rpeak is missing in the lscpu output of the machine.</p>
+        <p>Note: If neither Rpeak nor efficiency is available, it indicates that the 'max MHz' value necessary to calculate the Rpeak is missing in the lscpu output of the machine.</p>
         """
 
         # Compute Rpeak and get summary

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -1,0 +1,67 @@
+from elements.bench.base import AbstractBench
+
+import json
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+
+class Matrix_Bench(AbstractBench):
+    def __init__(self, obj, bench_obj):
+        self.obj = obj
+        self.bench_obj = bench_obj
+
+    def to_html(self):
+        self.gen_images()
+        wd = os.getcwd()
+        header = "<h2 id='Matrix_Bench'>Matrix Bench</h2>"
+        imgs = f"<img src='{wd}/out/matrix_benchmark_plot.png'/>"
+        p = "<p>Matrix benchmark results for DGEMM.</p>"
+        return header + imgs + p
+
+    def gen_images(self):
+        # Load data
+        data = self.obj
+        sizes = np.array(data["sizes"])
+        gflops = np.array(data["gflops"])
+        
+        
+
+# Load JSON data
+with open("matrix_dgemm_results.json", "r") as f:
+    data = json.load(f)
+
+results = data["results"]
+summary = data["summary"]
+
+sizes = [entry["size"] for entry in results]
+gflops = [entry["gflops"] for entry in results]
+
+# Plot the results
+plt.figure(figsize=(10, 6))
+plt.plot(sizes, gflops, marker='o', label="GFLOPS (by size)")
+plt.axhline(summary["gflops_max"], color='r', linestyle='--', label=f"Max: {summary['gflops_max']:.2f} GFLOPS")
+plt.axhline(summary["gflops_avg"], color='g', linestyle='--', label=f"Average: {summary['gflops_avg']:.2f} GFLOPS")
+
+# Formatting
+plt.title("DGEMM Benchmark - Performance in GFLOPS")
+plt.xlabel("Matrix size (N x N)")
+plt.ylabel("GFLOPS")
+plt.grid(True)
+plt.legend()
+plt.tight_layout()
+
+# Save the plot
+os.makedirs("out", exist_ok=True)
+plt.savefig("out/matrix_benchmark_plot.png")
+plt.close()
+
+# Show the plot        
+plt.show()
+
+def get_index(self):
+    return {
+        "title": "Matrix Bench",
+        "id": "Matrix_Bench",
+        "description": "Matrix benchmark results for DGEMM.",
+        "icon": "matrix_bench_icon.png"
+    }

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -1,9 +1,9 @@
 from elements.bench.base import AbstractBench
 
-import json
 import matplotlib.pyplot as plt
-import numpy as np
 import os
+import subprocess
+import sysconfig
 
 class Matrix_Bench(AbstractBench):
     def __init__(self, obj, bench_obj):
@@ -17,58 +17,113 @@ class Matrix_Bench(AbstractBench):
         header = "<h2 id='Matrix_Bench'>Matrix Multiplication DGEMM</h2>"
         imgs = f"<img src='{wd}/out/matrix_benchmark_plot.png'/>"
         p = "<p>This benchmark evaluates the performance of dense matrix multiplication using Eigen. Below is the GFLOPS achieved for various matrix sizes.</p>"
-        return header + imgs + p
+
+        # Compute Rpeak and get summary
+        rpeak, flops_unit, cores, freq = self.compute_rpeak()
+        gflops_max = self.bench_obj["summary"]["gflops_max"]
+
+        
+
+       
+
+        # Generate HTML table comparing theoretical and experimental
+        table = f"""
+        <h3>Performance Comparison</h3>
+        <table border='1' style='border-collapse: collapse; text-align: center;'>
+            <tr><th>Metric</th><th>Value</th></tr>
+            <tr><td>Theoretical Rpeak</td><td>{rpeak:.2f} GFLOPS</td></tr>
+            <tr><td>Experimental Max GFLOPS</td><td>{gflops_max:.2f}</td></tr>
+            <tr><td>FLOPs/cycle/core</td><td>{flops_unit}</td></tr>
+            <tr><td>Cores</td><td>{cores}</td></tr>
+            <tr><td>Clock Frequency</td><td>{freq:.2f} GHz</td></tr>
+        </table>
+        """
+
+        return header + imgs + p + table
 
     def gen_images(self):
-        # Access data directly from self.obj
-        # self.bench_obj is a dictionary containing the benchmark results
         results = self.bench_obj["results"]
         summary = self.bench_obj["summary"]
-    
+
         sizes = [entry["size"] for entry in results]
         gflops = [entry["Gflops"] for entry in results]
-   
+
         # Create the plot
         plt.figure(figsize=(10, 6))
         plt.plot(sizes, gflops, marker='o', color='blue', label="GFLOPS (per size)")
         plt.ylim(0)
-            
-        # Add lines for max and average GFLOPS
         plt.axhline(summary["gflops_max"], color='red', linestyle='--', label=f"Max GFLOPS: {summary['gflops_max']:.1f}")
         plt.axhline(summary["gflops_avg"], color='green', linestyle='--', label=f"Average GFLOPS: {summary['gflops_avg']:.1f}")
-     
-        # Add annotations on the points
+
         for x, y in zip(sizes, gflops):
             plt.text(x, y + 0.5, f"{y:.1f}", ha='center', fontsize=9)
-        
-        # Calculate the error (e.g., ±5% of GFLOPS values)
-        error = [0.05 * g for g in gflops]
 
-        # Plot the error band
+        error = [0.05 * g for g in gflops]
         plt.fill_between(
             sizes,
-            [g - e for g, e in zip(gflops, error)],  # Lower values
-            [g + e for g, e in zip(gflops, error)],  # Upper values
+            [g - e for g, e in zip(gflops, error)],
+            [g + e for g, e in zip(gflops, error)],
             color='cyan',
             alpha=0.2,
             label='Error Band (±5%)',
             edgecolor='blue',
-            linewidth=2,  
-        )        
+            linewidth=2,
+        )
 
-        # Format the plot
         plt.title("Matrix Multiplication performance (GFLOPS)")
         plt.xlabel("Matrix Size (N x N)")
         plt.ylabel("GFLOPS")
         plt.grid(True)
         plt.legend()
         plt.tight_layout()
-    
-        # Create the output directory and save the plot
         os.makedirs("out", exist_ok=True)
         plt.savefig("out/matrix_benchmark_plot.png", dpi=300)
         plt.close()
 
+    def compute_rpeak(self):
+        
+        data = self.obj
+        
+        cores_per_socket = data["meta"]["cpu_info"]["cpus"]
+        sockets = data["meta"]["cpu_info"]["sockets"]
+
+        num_cores = cores_per_socket * sockets
+
+        max_mhz = data["meta"]["cpu_info"]["max_mhz"] 
+        clock_ghz = max_mhz / 1000
+
+
+        flags = sysconfig.get_config_var("CFLAGS") #prenddre les flages du json plutot
+        flags = flags.split() if flags else []
+
+        if "avx512f" in flags:
+            flops_per_cycle_per_core = 32
+        elif "avx2" in flags:
+            flops_per_cycle_per_core = 16
+        elif "avx" in flags:
+            flops_per_cycle_per_core = 8
+        else:
+            flops_per_cycle_per_core = 4
+
+        rpeak = num_cores * clock_ghz * flops_per_cycle_per_core
+
+        print(f"max MHz: {max_mhz:.2f} MHz")
+        print(f"Max clock rate: {clock_ghz:.2f} GHz")
+        print(f"Number of cores: {num_cores}")  
+        print(f"Number of cores per socket: {cores_per_socket}")
+        print(f"rpeak: {rpeak:.2f} GFLOPS")
+
+
+        return rpeak, flops_per_cycle_per_core, num_cores, clock_ghz
+
     def get_index(self):
-        # Return the index entry for the Matrix Multiplication section
         return "<li><a href='#Matrix_Bench'>Matrix Multiplication DGEMM</a></li>"
+
+
+# faire la perf crête théorique : Rpeak = # of FP64 units (per core) * # of cores * max clock rate
+#mettre des warnings que le rpeak sur chaque architecture est arbitraire pour 2 threads par coeur
+#mettre un deuxieme warning pour dire que si le rpeak est plus petit que le expérimentale alors c'est pas bon
+
+# est-ce que sysconfig fonctionne sur ARM comme sur X86_64 ?
+
+# le pb c'est qu'il ne détecte pas le max MHz dans sysconf, il met 0 

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -104,21 +104,21 @@ class MatrixBench(AbstractBench):
 
         clock_ghz = max_mhz / 1000
 
-        flags = data["meta"]["cpu_info"].get("flags", "")
-        flags = flags.split() if flags else []
+        flags = data["meta"]["cpu_info"]["simd"]
 
         # Determine the number of FLOPS per cycle per core based on CPU flags
         # assuming 2 <SIMD_ISA_NAME> instructions/cycle/core, i.e. <FLOP/cycle/core> 
-        if "avx512f" in flags:
-            flops_per_cycle_per_core = 32
-        elif "avx2" in flags:
+        if "AVX512" in flags:
             flops_per_cycle_per_core = 16
-        elif "avx" in flags:
+        elif "AVX" in flags:
+            flops_per_cycle_per_core = 8
+        elif "SSE" in flags:
             flops_per_cycle_per_core = 8
         else:
             flops_per_cycle_per_core = 4
 
         rpeak = num_cores * clock_ghz * flops_per_cycle_per_core
+        print("flops_per_cycle_per_core", flops_per_cycle_per_core)
 
         # Check if Rpeak is lower than Rmax
         gflops_max = self.bench_obj["summary"]["gflops_max"]
@@ -126,7 +126,7 @@ class MatrixBench(AbstractBench):
             print(f"Warning: Rpeak ({rpeak:.2f} GFLOPS) is lower than Rmax ({gflops_max:.2f} GFLOPS). This result is unusual.")
 
         return rpeak, flops_per_cycle_per_core, num_cores, clock_ghz
-
+    
     
     def efficiency(self):
         data = self.obj

--- a/report/elements/bench/matrix_bench.py
+++ b/report/elements/bench/matrix_bench.py
@@ -18,7 +18,7 @@ class Matrix_Bench(AbstractBench):
         imgs = f"<img src='{wd}/out/matrix_benchmark_plot.png'/>"
         p = """
         <p>This benchmark evaluates the performance of dense matrix multiplication using Eigen. Below is the GFLOPS achieved for various matrix sizes.</p>
-        <p>Note: For the calculation of Rpeak, we arbitrarily assume 2 threads per core. If neither Rpeak nor efficiency is available, it indicates that the 'max MHz' value necessary to calculate the Rpeak is missing in the lscpu output of the machine.</p>
+        <p>Note: For the calculation of Rpeak, we assume 2 SIMD_ISA_NAME instructions/cycle/core, i.e. FLOP/cycle/core. If neither Rpeak nor efficiency is available, it indicates that the 'max MHz' value necessary to calculate the Rpeak is missing in the lscpu output of the machine.</p>
         """
 
         # Compute Rpeak and get summary
@@ -109,6 +109,8 @@ class Matrix_Bench(AbstractBench):
         flags = data["meta"]["cpu_info"].get("flags", "")
         flags = flags.split() if flags else []
 
+        # Determine the number of FLOPS per cycle per core based on CPU flags
+        # assuming 2 <SIMD_ISA_NAME> instructions/cycle/core, i.e. <FLOP/cycle/core> 
         if "avx512f" in flags:
             flops_per_cycle_per_core = 32
         elif "avx2" in flags:

--- a/src/PPN-microbench/CMakeLists.txt
+++ b/src/PPN-microbench/CMakeLists.txt
@@ -45,6 +45,4 @@ target_sources(PPN-microbench
 )
 
 set_target_properties(PPN-microbench PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
-target_link_libraries(PPN-microbench PRIVATE nlohmann_json::nlohmann_json spdlog::spdlog CLI11::CLI11)
-target_include_directories(PPN-microbench PRIVATE ${openblas_SOURCE_DIR})
-target_link_libraries(PPN-microbench PRIVATE openblas)
+target_link_libraries(PPN-microbench PRIVATE nlohmann_json::nlohmann_json spdlog::spdlog CLI11::CLI11 Eigen3::Eigen)

--- a/src/PPN-microbench/CMakeLists.txt
+++ b/src/PPN-microbench/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(PPN-microbench STATIC)
 
-target_sources(PPN-microbench PRIVATE microbench.cpp context.cpp driver.cpp ops.cpp cpu_frequency.cpp cache_latency.cpp core_to_core_latency.cpp)
+target_sources(PPN-microbench PRIVATE microbench.cpp context.cpp driver.cpp ops.cpp cpu_frequency.cpp cache_latency.cpp core_to_core_latency.cpp matrix_bench.cpp)
 
 target_sources(
     PPN-microbench
@@ -15,6 +15,7 @@ target_sources(
             ${PROJECT_SOURCE_DIR}/include/PPN-microbench/cache_latency.hpp
             ${PROJECT_SOURCE_DIR}/include/PPN-microbench/asm_functions.hpp
             ${PROJECT_SOURCE_DIR}/include/PPN-microbench/core_to_core_latency.hpp
+            ${PROJECT_SOURCE_DIR}/include/PPN-microbench/matrix_bench.hpp
 )
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|aarch64)")
@@ -45,3 +46,4 @@ target_sources(PPN-microbench
 
 set_target_properties(PPN-microbench PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
 target_link_libraries(PPN-microbench PRIVATE nlohmann_json::nlohmann_json spdlog::spdlog CLI11::CLI11)
+target_link_libraries(PPN-microbench PRIVATE openblas)

--- a/src/PPN-microbench/CMakeLists.txt
+++ b/src/PPN-microbench/CMakeLists.txt
@@ -46,4 +46,5 @@ target_sources(PPN-microbench
 
 set_target_properties(PPN-microbench PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
 target_link_libraries(PPN-microbench PRIVATE nlohmann_json::nlohmann_json spdlog::spdlog CLI11::CLI11)
+target_include_directories(PPN-microbench PRIVATE ${openblas_SOURCE_DIR})
 target_link_libraries(PPN-microbench PRIVATE openblas)

--- a/src/PPN-microbench/driver.cpp
+++ b/src/PPN-microbench/driver.cpp
@@ -15,7 +15,7 @@ Driver::Driver(int argc, char **argv) {
     app.add_flag_callback("--ops", [this](){this->addBench(new Ops(10));}, "Run operations/second benchmark");
     app.add_flag_callback("--c2c", [this](){this->addBench(new CoreToCoreLatency(10));}, "Run core to core latency benchmark");
     app.add_flag_callback("--cache-latency", [this](){this->addBench(new Cache_latency);}, "Run cpu ram/cache latency benchmark");
-    app.add_flag_callback("--matrix", [this](){this->addBench(new Matrix_bench);}, "Run matrix multiplication benchmark");
+    app.add_flag_callback("--matrix-mult", [this](){this->addBench(new Matrix_bench);}, "Run matrix multiplication benchmark");
     // benchmark group selection
     app.add_flag_callback("--cpu", [this](){this->addBench(new CPUFrequency(10)).addBench(new Ops(10)).addBench(new CoreToCoreLatency(10));}, "CPU related benchmarks");
     app.add_flag_callback("--mem", [this](){this->addBench(new Cache_latency);}, "Memory/cache related benchmarks");

--- a/src/PPN-microbench/driver.cpp
+++ b/src/PPN-microbench/driver.cpp
@@ -21,7 +21,7 @@ Driver::Driver(int argc, char **argv) {
     app.add_flag_callback("--stream", [this](){this->addBench(new Stream);}, "Run stream benchmark");
     app.add_flag_callback("--gpu-h2d-bandwidth", [this](){this->addBench(new GPUH2DBandwidth);}, "Run host to GPU memory bandwidth benchmark");
     // benchmark group selection
-    app.add_flag_callback("--cpu", [this](){this->addBench(new CPUFrequency(11)).addBench(new Ops(11)).addBench(new Matrix_bench).addBench(new LoadTest).addBench(new CoreToCoreLatency(11));}, "CPU related benchmarks");
+    app.add_flag_callback("--cpu", [this](){this->addBench(new CPUFrequency(11)).addBench(new Ops(11)).addBench(new Matrix_bench).addBench(new LoadTest(11)).addBench(new CoreToCoreLatency(11));}, "CPU related benchmarks");
     app.add_flag_callback("--mem", [this](){this->addBench(new CacheLatency).addBench(new MemoryBandwidth).addBench(new Stream);}, "Memory/cache related benchmarks");
     app.add_flag_callback("--gpu", [this](){this->addBench(new GPUH2DBandwidth);}, "GPU related benchmarks");
     // help message

--- a/src/PPN-microbench/driver.cpp
+++ b/src/PPN-microbench/driver.cpp
@@ -15,9 +15,11 @@ Driver::Driver(int argc, char **argv) {
     app.add_flag_callback("--ops", [this](){this->addBench(new Ops(10));}, "Run operations/second benchmark");
     app.add_flag_callback("--c2c", [this](){this->addBench(new CoreToCoreLatency(10));}, "Run core to core latency benchmark");
     app.add_flag_callback("--cache-latency", [this](){this->addBench(new Cache_latency);}, "Run cpu ram/cache latency benchmark");
+    app.add_flag_callback("--matrix", [this](){this->addBench(new Matrix_bench);}, "Run matrix multiplication benchmark");
     // benchmark group selection
     app.add_flag_callback("--cpu", [this](){this->addBench(new CPUFrequency(10)).addBench(new Ops(10)).addBench(new CoreToCoreLatency(10));}, "CPU related benchmarks");
     app.add_flag_callback("--mem", [this](){this->addBench(new Cache_latency);}, "Memory/cache related benchmarks");
+
     
     // help message
     app.set_help_flag("-h, --help", "Show this help message");
@@ -34,6 +36,7 @@ Driver::Driver(int argc, char **argv) {
         addBench(new Ops(10));
         addBench(new CoreToCoreLatency(10));
         addBench(new Cache_latency);
+        addBench(new Matrix_bench);
     }
 
     run();

--- a/src/PPN-microbench/matrix_bench.cpp
+++ b/src/PPN-microbench/matrix_bench.cpp
@@ -1,6 +1,6 @@
 #include <PPN-microbench/matrix_bench.hpp>
 
-Matrix_bench::Matrix_bench() {
+Matrix_bench::Matrix_bench() : Microbench("Matrix Multiplication", 1) {
     // Initialize the memory sizes in bytes for the benchmark
     mem_sizes = {256, 512, 1024, 2048};
 }
@@ -50,8 +50,8 @@ json Matrix_bench::getJson() {
     
     // Create a JSON object to store the summary
     json summary = {
-        {"gflops_max", max_flops},
-        {"gflops_avg", avg_flops},
+        {"gflops_max", max_gflops},
+        {"gflops_avg", avg_gflops},
         {"time_avg", avg_time}
     };
 

--- a/src/PPN-microbench/matrix_bench.cpp
+++ b/src/PPN-microbench/matrix_bench.cpp
@@ -8,14 +8,20 @@ Matrix_bench::Matrix_bench() : Microbench("Matrix Multiplication", 1) {
 Matrix_bench::~Matrix_bench() {}
 
 void Matrix_bench::run() {
+    const int repeats = 5; // Number of repeats for each benchmark
     for (auto N : mem_sizes) {
+        double total_duration = 0.0;
+        double total_gflops = 0.0;
+    
+        for (int i = 0; i < repeats; ++i) {
+            
         Eigen::MatrixXd A = Eigen::MatrixXd::Random(N, N);
         Eigen::MatrixXd B = Eigen::MatrixXd::Random(N, N);
         Eigen::MatrixXd C = Eigen::MatrixXd::Random(N, N);
 
         auto start = std::chrono::high_resolution_clock::now();
 
-        // Perform matrix multiplication using Eigen
+        // Perform Dense matrix multiplication using Eigen same as DGEMM
         C = A * B;
 
         auto end = std::chrono::high_resolution_clock::now();
@@ -25,6 +31,15 @@ void Matrix_bench::run() {
         double ops = 2.0 * N * N * N; // Number of double-precision operations
         double Gflop_rate = (ops / duration)/1e9; // Gflop/s
 
+        total_duration += duration;
+        total_gflops += Gflop_rate;
+        }
+
+        // Calculate the average results over the repetitions
+        double duration = total_duration / repeats;
+        double Gflop_rate = total_gflops / repeats;
+        
+        // Store the results
         time_seconds.push_back(duration);
         Gflops.push_back(Gflop_rate);
     }

--- a/src/PPN-microbench/matrix_bench.cpp
+++ b/src/PPN-microbench/matrix_bench.cpp
@@ -1,0 +1,62 @@
+#include <PPN-microbench/matrix_bench.hpp>
+
+Matrix_bench::Matrix_bench() {
+    // Initialize the memory sizes in bytes for the benchmark
+    mem_sizes = {256, 512, 1024, 2048};
+}
+
+Matrix_bench::~Matrix_bench() {}
+
+void Matrix_bench::run() {
+    for (auto N : mem_sizes) {
+        std::vector<double> A(N * N, 1.0);
+        std::vector<double> B(N * N, 1.0);
+        std::vector<double> C(N * N, 0.0);
+
+        auto start = std::chrono::high_resolution_clock::now();
+
+        // Perform matrix multiplication using cblas_dgemm
+        cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                    N, N, N,
+                    1.0, A.data(), N, B.data(), N,
+                    0.0, C.data(), N);
+
+        auto end = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> elapsed = end - start;
+
+        double duration = elapsed.count();
+        double ops = 2.0 * N * N * N; // Number of double-precision operations
+        double Gflop_rate = (ops / duration)/1e9; // Gflop/s
+
+        time_seconds.push_back(duration);
+        Gflops.push_back(Gflop_rate);
+    }
+}
+
+json Matrix_bench::getJson() {
+    json j;
+    for (size_t i = 0; i < mem_sizes.size(); ++i) {
+        j.push_back({
+            {"size", mem_sizes[i]},
+            {"time_seconds", time_seconds[i]},
+            {"Gflops", Gflops[i]}
+        });
+    }
+    // Calculate the maximum Gflops to get the highest performance peak
+    // Calculate the average Gflops and time to get the typical performance
+    double max_gflops = *std::max_element(Gflops.begin(), Gflops.end());
+    double avg_gflops = std::accumulate(Gflops.begin(), Gflops.end(), 0.0) / Gflops.size();
+    double avg_time = std::accumulate(time_seconds.begin(), time_seconds.end(), 0.0) / time_seconds.size();
+    
+    // Create a JSON object to store the summary
+    json summary = {
+        {"gflops_max", max_flops},
+        {"gflops_avg", avg_flops},
+        {"time_avg", avg_time}
+    };
+
+    return {
+        {"results", j},
+        {"summary", summary}
+    };
+}

--- a/src/PPN-microbench/matrix_bench.cpp
+++ b/src/PPN-microbench/matrix_bench.cpp
@@ -9,17 +9,14 @@ Matrix_bench::~Matrix_bench() {}
 
 void Matrix_bench::run() {
     for (auto N : mem_sizes) {
-        std::vector<double> A(N * N, 1.0);
-        std::vector<double> B(N * N, 1.0);
-        std::vector<double> C(N * N, 0.0);
+        Eigen::MatrixXd A = Eigen::MatrixXd::Random(N, N);
+        Eigen::MatrixXd B = Eigen::MatrixXd::Random(N, N);
+        Eigen::MatrixXd C = Eigen::MatrixXd::Random(N, N);
 
         auto start = std::chrono::high_resolution_clock::now();
 
-        // Perform matrix multiplication using cblas_dgemm
-        cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-                    N, N, N,
-                    1.0, A.data(), N, B.data(), N,
-                    0.0, C.data(), N);
+        // Perform matrix multiplication using Eigen
+        C = A * B;
 
         auto end = std::chrono::high_resolution_clock::now();
         std::chrono::duration<double> elapsed = end - start;
@@ -56,6 +53,7 @@ json Matrix_bench::getJson() {
     };
 
     return {
+        {"name", name},
         {"results", j},
         {"summary", summary}
     };

--- a/src/PPN-microbench/matrix_bench.cpp
+++ b/src/PPN-microbench/matrix_bench.cpp
@@ -2,7 +2,7 @@
 
 Matrix_bench::Matrix_bench() : Microbench("Matrix Multiplication", 1) {
     // Initialize the memory sizes in bytes for the benchmark
-    mem_sizes = {256, 512, 1024, 2048};
+    mem_sizes = {256, 512, 1024, 2048, 4096, 8192};
 }
 
 Matrix_bench::~Matrix_bench() {}

--- a/src/PPN-microbench/matrix_bench.cpp
+++ b/src/PPN-microbench/matrix_bench.cpp
@@ -1,15 +1,24 @@
 #include <PPN-microbench/matrix_bench.hpp>
 
 Matrix_bench::Matrix_bench() : Microbench("Matrix Multiplication", 1) {
-    // Initialize the memory sizes in bytes for the benchmark
-    mem_sizes = {256, 512, 1024, 2048, 4096, 8192};
+    // Determine the number of iterations based on the number of physical cores
+        int num_cores;
+        num_cores = context.getCpus(); 
+        std::cout << "Number of physical cores " << num_cores << std::endl;
+        int max_iterations = num_cores;
+
+    // Initialize the N size for N*N matrix for the benchmark
+    for (int i = 1; i <= max_iterations; ++i) {
+        N_sizes.push_back(512 * i);
+    }
 }
+
 
 Matrix_bench::~Matrix_bench() {}
 
 void Matrix_bench::run() {
     const int repeats = 5; // Number of repeats for each benchmark
-    for (auto N : mem_sizes) {
+    for (auto N : N_sizes) {
         double total_duration = 0.0;
         double total_gflops = 0.0;
     
@@ -47,9 +56,9 @@ void Matrix_bench::run() {
 
 json Matrix_bench::getJson() {
     json j;
-    for (size_t i = 0; i < mem_sizes.size(); ++i) {
+    for (size_t i = 0; i < N_sizes.size(); ++i) {
         j.push_back({
-            {"size", mem_sizes[i]},
+            {"size", N_sizes[i]},
             {"time_seconds", time_seconds[i]},
             {"Gflops", Gflops[i]}
         });


### PR DESCRIPTION
This pull request introduces a new matrix multiplication benchmark using the Eigen library, along with several supporting changes to integrate it into the codebase. The most important changes include adding the `Matrix_bench` class, updating the build system to include Eigen and the new benchmark, and enhancing the `Context` class to capture maximum CPU frequency for performance calculations.

### Matrix Multiplication Benchmark Integration:
* Added `Matrix_bench` class to implement a matrix multiplication benchmark using Eigen, including methods for running the benchmark, generating JSON results, and calculating performance metrics. (`include/PPN-microbench/matrix_bench.hpp`, `src/PPN-microbench/matrix_bench.cpp`, [[1]](diffhunk://#diff-fcdc349ac87eabefbfc4b26f21d9d5cba01018bcb25b357bd6532d5da3e5f372R1-R40) [[2]](diffhunk://#diff-40795be2f7b0b27fe0c01db2ef7f9ef75e6a3c619c5ed915d768ff21b0e8b5a4R1-R88)
* Updated `Driver` class to include the new benchmark in the available options and default benchmarks. (`src/PPN-microbench/driver.cpp`, [[1]](diffhunk://#diff-a363031ccd0e42bd332baa5aeca19ee5bcac05d33ffb0ac18bce0c985e3c2c92L14-R25) [[2]](diffhunk://#diff-a363031ccd0e42bd332baa5aeca19ee5bcac05d33ffb0ac18bce0c985e3c2c92L39-R42)
* Integrated the benchmark into the reporting system by adding `MatrixBench` to the Python reporting module and generating a detailed HTML report with performance metrics and plots. (`report/elements/bench/matrix_bench.py`, `report/elements/base.py`, `report/elements/bench/__init__.py`, [[1]](diffhunk://#diff-a93ed3d9b1ab082218dc8f528ea6b6da30639e7c4034f43ca3634188b076ec29R1-R148) [[2]](diffhunk://#diff-d9f4ec4c6d52e56758bf9be7fcf94f0dbbacbe07bd102787c74ad617ad625a0eL27-R29) [[3]](diffhunk://#diff-750b5d339a71d8e842dc88276d578e4e0be363fca4f573d2a2a633aceb8d521cR5)

### Build System Updates:
* Added Eigen as a dependency using `FetchContent` in `CMakeLists.txt` and linked it to the main executable and `PPN-microbench` library. (`CMakeLists.txt`, `main/CMakeLists.txt`, `src/PPN-microbench/CMakeLists.txt`, [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR29-R36) [[2]](diffhunk://#diff-e1bc61f89706898f754134386b0c25982fa6dd53e2c7172f66d36a9f6b773dc5L3-R3) [[3]](diffhunk://#diff-e0e48717c062225a9c46551aa28b8bdf9347b3936bc304c835ca613228be023fR32) [[4]](diffhunk://#diff-e0e48717c062225a9c46551aa28b8bdf9347b3936bc304c835ca613228be023fL54-R56)

### Enhancements to `Context` Class:
* Added `max_mhz` attribute to the `Context` class to store the maximum CPU frequency, extracted using the `lscpu` command. This information is used in performance calculations. (`include/PPN-microbench/context.hpp`, `src/PPN-microbench/context.cpp`, [[1]](diffhunk://#diff-3145161538036381a3a9401a63c43a31154c274d56ba1d975207708933a528acR17-R40) [[2]](diffhunk://#diff-3145161538036381a3a9401a63c43a31154c274d56ba1d975207708933a528acR64) [[3]](diffhunk://#diff-7fcce165688f099e04194c62225f2833a15ec0f0d92d3d34818a6fef10a092ddR72-R134) [[4]](diffhunk://#diff-7fcce165688f099e04194c62225f2833a15ec0f0d92d3d34818a6fef10a092ddR229-R232)

### Minor Improvements:
* Fixed typos in comments in the `Context` class. (`include/PPN-microbench/context.hpp`, [include/PPN-microbench/context.hppR17-R40](diffhunk://#diff-3145161538036381a3a9401a63c43a31154c274d56ba1d975207708933a528acR17-R40))
* Adjusted error band label in cache latency plots for clarity. (`report/elements/bench/cache_latency.py`, [report/elements/bench/cache_latency.pyL79-R79](diffhunk://#diff-bbcd4be1fcea0959380772b6fc6099a2c07095c945398bfcb023023cecf31fa2L79-R79))

### Reported error

I don't no why, but the Rmax > Rpeak when I run the benchmark. This result is unusual. I don't know where it comes from. Before the merge on average the Rmax = 42 < Rpeak = 72 , and now Rmax = 135 > Rpeak = 72. If someone could check it for me please. ( I compare the 2 versions and I don't find where could be the changing factor for this issue ).   
