### PR TITLE
Final (?) hotfix for big computer

### DIFF
--- a/include/PPN-microbench/context.hpp
+++ b/include/PPN-microbench/context.hpp
@@ -30,8 +30,10 @@ class Context {
     size_t sockets;
     // Amount of physical cores on the node
     size_t cpus;
+    size_t cpusPerSocket;
     // Amount of virtural core on the node
     size_t threads;
+    size_t threadsPerCore;
     // Mapping of the virtual cores to the physical ones
     std::vector<size_t> threadMapping;
     //Max cpu frequency

--- a/include/PPN-microbench/context.hpp
+++ b/include/PPN-microbench/context.hpp
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <iostream>
 #include <sstream>
+#include <algorithm>
 
 using json = nlohmann::ordered_json;
 

--- a/src/PPN-microbench/context.cpp
+++ b/src/PPN-microbench/context.cpp
@@ -74,9 +74,6 @@ void Context::cpuInfo() {
     double max_mhz = 0.0;
     system("lscpu > /tmp/lscpu_out.txt");
     std::ifstream f_re("/tmp/lscpu_out.txt");
-    // std::ifstream f_re("lscpu");
-
-    
 
     if (!f_re.is_open()) {
         spdlog::warn("Error opening /tmp/lscpu_out.txt");
@@ -159,7 +156,6 @@ void Context::cpuInfo() {
     //////////
 
     std::ifstream f("/proc/cpuinfo");
-    // std::ifstream f("cpuinfo");
     std::string line;
 
     int64_t coreIds = 0;

--- a/src/PPN-microbench/context.cpp
+++ b/src/PPN-microbench/context.cpp
@@ -178,6 +178,7 @@ void Context::cpuInfo() {
     size_t currProc = 0;
     size_t currCore = 0;
     size_t socket = 0;
+    threads = 0;
     int64_t topo[sockets][coreIds][threadsPerCore];
 
     for (size_t s = 0; s < sockets; s++) {
@@ -193,6 +194,7 @@ void Context::cpuInfo() {
         if (line.find("processor") != std::string::npos) {
             currProc = getFirstInt(line);
             currCore = currProc;
+            threads += 1;
         }
 
         if (line.find("core id") != std::string::npos) {
@@ -221,7 +223,6 @@ void Context::cpuInfo() {
     }
 
     cpus = sockets * cpusPerSocket;
-    threads = sockets * cpusPerSocket * threadsPerCore;
     f.close();
 }
 

--- a/src/PPN-microbench/context.cpp
+++ b/src/PPN-microbench/context.cpp
@@ -72,7 +72,7 @@ void Context::cpuInfo() {
 
     
     double max_mhz = 0.0;
-    system("lscpu > /tmp/lscpu_out.txt");
+    int _ =system("lscpu > /tmp/lscpu_out.txt");
     std::ifstream f_re("/tmp/lscpu_out.txt");
 
     if (!f_re.is_open()) {
@@ -209,15 +209,13 @@ void Context::cpuInfo() {
                 i++;
             }
             topo[socket][currCore][i] = currProc;
-            spdlog::info("{} {} {}", socket, currCore, currProc);
+            spdlog::debug("sock:{} core:{} thread:{}", socket, currCore, currProc);
         }
     }
 
     for (int soc = 0; soc < sockets; soc++) {
-        spdlog::warn("haha");
         for (int cor = 0; cor < coreIds; cor++) {
             int64_t proc = topo[soc][cor][0];
-            spdlog::warn("{} {} {}", soc, cor, proc);
             if (proc > -1) threadMapping.push_back(proc);
         }
     }

--- a/src/PPN-microbench/context.cpp
+++ b/src/PPN-microbench/context.cpp
@@ -174,6 +174,11 @@ void Context::cpuInfo() {
     f.seekg(0);
     coreIds++;
 
+    // Arm cpus usually don't report core id in /proc/cpuinfo
+    if (coreIds == 1) {
+        coreIds = sockets * threadsPerCore * cpusPerSocket;
+    }
+
     size_t currProc = 0;
     size_t currCore = 0;
     size_t socket = 0;

--- a/src/PPN-microbench/driver.cpp
+++ b/src/PPN-microbench/driver.cpp
@@ -35,15 +35,15 @@ Driver::Driver(int argc, char **argv) {
     }
 
     if (benches.size() == 0) {
-        // addBench(new Ops(11));
-        // addBench(new CPUFrequency(11));
-        // addBench(new LoadTest(11));
-        // addBench(new CoreToCoreLatency(11));
-        // addBench(new CacheLatency());
-        // addBench(new MemoryBandwidth);
-        // addBench(new Stream);
-        // addBench(new GPUH2DBandwidth);
-        // addBench(new MatMulBench(11));
+        addBench(new Ops(11));
+        addBench(new CPUFrequency(11));
+        addBench(new LoadTest(11));
+        addBench(new CoreToCoreLatency(11));
+        addBench(new CacheLatency());
+        addBench(new MemoryBandwidth);
+        addBench(new Stream);
+        addBench(new GPUH2DBandwidth);
+        addBench(new MatMulBench(11));
     }
 
     run();

--- a/src/PPN-microbench/driver.cpp
+++ b/src/PPN-microbench/driver.cpp
@@ -35,15 +35,15 @@ Driver::Driver(int argc, char **argv) {
     }
 
     if (benches.size() == 0) {
-        addBench(new Ops(11));
-        addBench(new CPUFrequency(11));
-        addBench(new LoadTest(11));
-        addBench(new CoreToCoreLatency(11));
-        addBench(new CacheLatency());
-        addBench(new MemoryBandwidth);
-        addBench(new Stream);
-        addBench(new GPUH2DBandwidth);
-        addBench(new MatMulBench(11));
+        // addBench(new Ops(11));
+        // addBench(new CPUFrequency(11));
+        // addBench(new LoadTest(11));
+        // addBench(new CoreToCoreLatency(11));
+        // addBench(new CacheLatency());
+        // addBench(new MemoryBandwidth);
+        // addBench(new Stream);
+        // addBench(new GPUH2DBandwidth);
+        // addBench(new MatMulBench(11));
     }
 
     run();


### PR DESCRIPTION
Thread to core to socket mapping really needs a better implementation, either by using `lscpu --all --extended` or directly by `lstopo` to get caches at the same time 