### PR TITLE
Fix: removed dependencies in OPS asm

### DIFF
--- a/report/elements/bench/ops.py
+++ b/report/elements/bench/ops.py
@@ -48,9 +48,9 @@ class Ops(AbstractBench):
         table += "<tr><th>f64 SIMD</th><td>{:10.4f}</td><td>{:10.4f}</td><td>{:10.4f}</td></tr>".format(t[5][0], t[5][1], t[5][2])
         table = f"<table>{table}</table>"
 
-        imgs = f"<img src='{wd}/out/ops_scalar.svg'/></br><img src='{wd}/out/ops_simd.svg'/>"
+        txt = f"Operations are performed in assembly on (at least) 8 different registers, with no dependencies."
         
-        return header + p1 + table
+        return header + p1 + table + txt
 
     def gen_images(self):
         x = [i for i in range(len(self.data[0]))]

--- a/src/PPN-microbench/asm/add_arm.S
+++ b/src/PPN-microbench/asm/add_arm.S
@@ -10,7 +10,7 @@
 
 ADD_ARM_i32:
 loop1:
-    add w0, w0, w0
+    add w9, w9, w9
     add w1, w1, w1
     add w2, w2, w2
     add w3, w3, w3
@@ -18,7 +18,7 @@ loop1:
     add w5, w5, w5
     add w6, w6, w6
     add w7, w7, w7
-    add w0, w0, w0
+    add w9, w9, w9
     add w1, w1, w1
     add w2, w2, w2
     add w3, w3, w3
@@ -33,7 +33,7 @@ loop1:
 
 ADD_ARM_i64:
 loop2:
-    add x0, x0, x0
+    add x9, x9, x9
     add x1, x1, x1
     add x2, x2, x2
     add x3, x3, x3
@@ -41,7 +41,7 @@ loop2:
     add x5, x5, x5
     add x6, x6, x6
     add x7, x7, x7
-    add x0, x0, x0
+    add x9, x9, x9
     add x1, x1, x1
     add x2, x2, x2
     add x3, x3, x3

--- a/src/PPN-microbench/asm/add_arm.S
+++ b/src/PPN-microbench/asm/add_arm.S
@@ -10,22 +10,22 @@
 
 ADD_ARM_i32:
 loop1:
+    add w0, w0, w0
     add w1, w1, w1
+    add w2, w2, w2
+    add w3, w3, w3
+    add w4, w4, w4
+    add w5, w5, w5
+    add w6, w6, w6
+    add w7, w7, w7
+    add w0, w0, w0
     add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
-    add w1, w1, w1
+    add w2, w2, w2
+    add w3, w3, w3
+    add w4, w4, w4
+    add w5, w5, w5
+    add w6, w6, w6
+    add w7, w7, w7
     
     subs x0, x0, #1
     bgt loop1
@@ -33,22 +33,22 @@ loop1:
 
 ADD_ARM_i64:
 loop2:
+    add x0, x0, x0
     add x1, x1, x1
+    add x2, x2, x2
+    add x3, x3, x3
+    add x4, x4, x4
+    add x5, x5, x5
+    add x6, x6, x6
+    add x7, x7, x7
+    add x0, x0, x0
     add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
-    add x1, x1, x1
+    add x2, x2, x2
+    add x3, x3, x3
+    add x4, x4, x4
+    add x5, x5, x5
+    add x6, x6, x6
+    add x7, x7, x7
     
     subs x0, x0, #1
     bgt loop2
@@ -57,21 +57,21 @@ loop2:
 ADD_ARM_f32:
 loop3:
     fadd s0, s0, s0
+    fadd s1, s1, s1
+    fadd s2, s2, s2
+    fadd s3, s3, s3
+    fadd s4, s4, s4
+    fadd s5, s5, s5
+    fadd s6, s6, s6
+    fadd s7, s7, s7
     fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
-    fadd s0, s0, s0
+    fadd s1, s1, s1
+    fadd s2, s2, s2
+    fadd s3, s3, s3
+    fadd s4, s4, s4
+    fadd s5, s5, s5
+    fadd s6, s6, s6
+    fadd s7, s7, s7
 
     subs x0, x0, #1
     bgt loop3
@@ -80,21 +80,21 @@ loop3:
 ADD_ARM_f64:
 loop4:
     fadd d0, d0, d0
+    fadd d1, d1, d1
+    fadd d2, d2, d2
+    fadd d3, d3, d3
+    fadd d4, d4, d4
+    fadd d5, d5, d5
+    fadd d6, d6, d6
+    fadd d7, d7, d7
     fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
-    fadd d0, d0, d0
+    fadd d1, d1, d1
+    fadd d2, d2, d2
+    fadd d3, d3, d3
+    fadd d4, d4, d4
+    fadd d5, d5, d5
+    fadd d6, d6, d6
+    fadd d7, d7, d7
 
     subs x0, x0, #1
     bgt loop4
@@ -103,21 +103,21 @@ loop4:
 ADD_ARM_i64_NEON:
 loop5:
     addp v0.8b, v0.8b, v0.8b
+    addp v1.8b, v1.8b, v1.8b
+    addp v2.8b, v2.8b, v2.8b
+    addp v3.8b, v3.8b, v3.8b
+    addp v4.8b, v4.8b, v4.8b
+    addp v5.8b, v5.8b, v5.8b
+    addp v6.8b, v6.8b, v6.8b
+    addp v7.8b, v7.8b, v7.8b
     addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
-    addp v0.8b, v0.8b, v0.8b
+    addp v1.8b, v1.8b, v1.8b
+    addp v2.8b, v2.8b, v2.8b
+    addp v3.8b, v3.8b, v3.8b
+    addp v4.8b, v4.8b, v4.8b
+    addp v5.8b, v5.8b, v5.8b
+    addp v6.8b, v6.8b, v6.8b
+    addp v7.8b, v7.8b, v7.8b
 
     subs x0, x0, #1
     bgt loop5
@@ -126,20 +126,21 @@ loop5:
 ADD_ARM_f64_NEON:
 loop6:
     faddp v0.2d, v0.2d, v0.2d
+    faddp v1.2d, v1.2d, v1.2d
+    faddp v2.2d, v2.2d, v2.2d
+    faddp v3.2d, v3.2d, v3.2d
+    faddp v4.2d, v4.2d, v4.2d
+    faddp v5.2d, v5.2d, v5.2d
+    faddp v6.2d, v6.2d, v6.2d
+    faddp v7.2d, v7.2d, v7.2d
     faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
-    faddp v0.2d, v0.2d, v0.2d
+    faddp v1.2d, v1.2d, v1.2d
+    faddp v2.2d, v2.2d, v2.2d
+    faddp v3.2d, v3.2d, v3.2d
+    faddp v4.2d, v4.2d, v4.2d
+    faddp v5.2d, v5.2d, v5.2d
+    faddp v6.2d, v6.2d, v6.2d
+    faddp v7.2d, v7.2d, v7.2d
 
     subs x0, x0, #1
     bgt loop6

--- a/src/PPN-microbench/asm/add_x86.S
+++ b/src/PPN-microbench/asm/add_x86.S
@@ -23,21 +23,21 @@
 ADD_X86_i32:
 loop1:
     addl %R8D, %R8D
+    addl %R9D, %R9D
+    addl %R10D, %R10D
+    addl %R11D, %R11D
+    addl %R12D, %R12D
+    addl %R13D, %R13D
+    addl %R14D, %R14D
+    addl %R15D, %R15D
     addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
-    addl %R8D, %R8D
+    addl %R9D, %R9D
+    addl %R10D, %R10D
+    addl %R11D, %R11D
+    addl %R12D, %R12D
+    addl %R13D, %R13D
+    addl %R14D, %R14D
+    addl %R15D, %R15D
 
     subq $1, %rdi
     jg loop1
@@ -46,21 +46,21 @@ loop1:
 ADD_X86_i64:
 loop2:
     addq %R8, %R8
+    addq %R9, %R9
+    addq %R10, %R10
+    addq %R11, %R11
+    addq %R12, %R12
+    addq %R13, %R13
+    addq %R14, %R14
+    addq %R15, %R15
     addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
-    addq %R8, %R8
+    addq %R9, %R9
+    addq %R10, %R10
+    addq %R11, %R11
+    addq %R12, %R12
+    addq %R13, %R13
+    addq %R14, %R14
+    addq %R15, %R15
 
     subq $1, %rdi
     jg loop2
@@ -69,21 +69,21 @@ loop2:
 ADD_X86_f32:
 loop3:
     addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
-    addss %xmm0, %xmm0
+    addss %xmm1, %xmm1
+    addss %xmm2, %xmm2
+    addss %xmm3, %xmm3
+    addss %xmm4, %xmm4
+    addss %xmm5, %xmm5
+    addss %xmm6, %xmm6
+    addss %xmm7, %xmm7
+    addss %xmm8, %xmm8
+    addss %xmm9, %xmm9
+    addss %xmm10, %xmm10
+    addss %xmm10, %xmm10
+    addss %xmm11, %xmm11
+    addss %xmm12, %xmm12
+    addss %xmm13, %xmm13
+    addss %xmm14, %xmm14
 
     subq $1, %rdi
     jg loop3
@@ -92,21 +92,21 @@ loop3:
 ADD_X86_f64:
 loop4:
     addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
-    addsd %xmm0, %xmm0
+    addsd %xmm1, %xmm1
+    addsd %xmm2, %xmm2
+    addsd %xmm3, %xmm3
+    addsd %xmm4, %xmm4
+    addsd %xmm5, %xmm5
+    addsd %xmm6, %xmm6
+    addsd %xmm7, %xmm7
+    addsd %xmm8, %xmm8
+    addsd %xmm9, %xmm9
+    addsd %xmm10, %xmm10
+    addsd %xmm10, %xmm10
+    addsd %xmm11, %xmm11
+    addsd %xmm12, %xmm12
+    addsd %xmm13, %xmm13
+    addsd %xmm14, %xmm14
 
     subq $1, %rdi
     jg loop4
@@ -121,21 +121,21 @@ loop4:
 ADD_X86_i64_SSE:
 loop5:
     paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
-    paddq %xmm0, %xmm0
+    paddq %xmm1, %xmm1
+    paddq %xmm2, %xmm2
+    paddq %xmm3, %xmm3
+    paddq %xmm4, %xmm4
+    paddq %xmm5, %xmm5
+    paddq %xmm6, %xmm6
+    paddq %xmm7, %xmm7
+    paddq %xmm8, %xmm8
+    paddq %xmm9, %xmm9
+    paddq %xmm10, %xmm10
+    paddq %xmm11, %xmm11
+    paddq %xmm12, %xmm12
+    paddq %xmm13, %xmm13
+    paddq %xmm14, %xmm14
+    paddq %xmm15, %xmm15
 
     subq $1, %rdi
     jg loop5
@@ -144,21 +144,21 @@ loop5:
 ADD_X86_f64_SSE:
 loop6:
     addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
-    addpd %xmm0, %xmm0
+    addpd %xmm1, %xmm1
+    addpd %xmm2, %xmm2
+    addpd %xmm3, %xmm3
+    addpd %xmm4, %xmm4
+    addpd %xmm5, %xmm5
+    addpd %xmm6, %xmm6
+    addpd %xmm7, %xmm7
+    addpd %xmm8, %xmm8
+    addpd %xmm9, %xmm9
+    addpd %xmm10, %xmm10
+    addpd %xmm11, %xmm11
+    addpd %xmm12, %xmm12
+    addpd %xmm13, %xmm13
+    addpd %xmm14, %xmm14
+    addpd %xmm15, %xmm15
 
     subq $1, %rdi
     jg loop6
@@ -173,21 +173,21 @@ loop6:
 ADD_X86_f64_AVX:
 loop7:
     vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
-    vaddpd %ymm0, %ymm0, %ymm0
+    vaddpd %ymm1, %ymm1, %ymm1
+    vaddpd %ymm2, %ymm2, %ymm2
+    vaddpd %ymm3, %ymm3, %ymm3
+    vaddpd %ymm4, %ymm4, %ymm4
+    vaddpd %ymm5, %ymm5, %ymm5
+    vaddpd %ymm6, %ymm6, %ymm6
+    vaddpd %ymm7, %ymm7, %ymm7
+    vaddpd %ymm8, %ymm8, %ymm8
+    vaddpd %ymm9, %ymm9, %ymm9
+    vaddpd %ymm10, %ymm10, %ymm10
+    vaddpd %ymm11, %ymm11, %ymm11
+    vaddpd %ymm12, %ymm12, %ymm12
+    vaddpd %ymm13, %ymm13, %ymm13
+    vaddpd %ymm14, %ymm14, %ymm14
+    vaddpd %ymm15, %ymm15, %ymm15
 
     subq $1, %rdi
     jg loop7
@@ -202,21 +202,21 @@ loop7:
 ADD_X86_i64_AVX:
 loop8:
     vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
-    vpaddq %ymm0, %ymm0, %ymm0
+    vpaddq %ymm1, %ymm1, %ymm1
+    vpaddq %ymm2, %ymm2, %ymm2
+    vpaddq %ymm3, %ymm3, %ymm3
+    vpaddq %ymm4, %ymm4, %ymm4
+    vpaddq %ymm5, %ymm5, %ymm5
+    vpaddq %ymm6, %ymm6, %ymm6
+    vpaddq %ymm7, %ymm7, %ymm7
+    vpaddq %ymm8, %ymm8, %ymm8
+    vpaddq %ymm9, %ymm9, %ymm9
+    vpaddq %ymm10, %ymm10, %ymm10
+    vpaddq %ymm11, %ymm11, %ymm11
+    vpaddq %ymm12, %ymm12, %ymm12
+    vpaddq %ymm13, %ymm13, %ymm13
+    vpaddq %ymm14, %ymm14, %ymm14
+    vpaddq %ymm15, %ymm15, %ymm15
 
     subq $1, %rdi
     jg loop8
@@ -230,22 +230,22 @@ loop8:
 
 ADD_X86_i64_AVX512:
 loop9:
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
-    vpaddq %zmm0, %zmm0, %zmm0
+    vpaddq %Zmm0, %Zmm0, %Zmm0
+    vpaddq %Zmm1, %Zmm1, %Zmm1
+    vpaddq %Zmm2, %Zmm2, %Zmm2
+    vpaddq %Zmm3, %Zmm3, %Zmm3
+    vpaddq %Zmm4, %Zmm4, %Zmm4
+    vpaddq %Zmm5, %Zmm5, %Zmm5
+    vpaddq %Zmm6, %Zmm6, %Zmm6
+    vpaddq %Zmm7, %Zmm7, %Zmm7
+    vpaddq %Zmm8, %Zmm8, %Zmm8
+    vpaddq %Zmm9, %Zmm9, %Zmm9
+    vpaddq %Zmm10, %Zmm10, %Zmm10
+    vpaddq %Zmm11, %Zmm11, %Zmm11
+    vpaddq %Zmm12, %Zmm12, %Zmm12
+    vpaddq %Zmm13, %Zmm13, %Zmm13
+    vpaddq %Zmm14, %Zmm14, %Zmm14
+    vpaddq %Zmm15, %Zmm15, %Zmm15
 
     subq $1, %rdi
     jg loop9
@@ -253,22 +253,22 @@ loop9:
 
 ADD_X86_f64_AVX512:
 loop10:
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
-    vaddpd %zmm0, %zmm0, %zmm0
+    vaddpd %Zmm0, %Zmm0, %Zmm0
+    vaddpd %Zmm1, %Zmm1, %Zmm1
+    vaddpd %Zmm2, %Zmm2, %Zmm2
+    vaddpd %Zmm3, %Zmm3, %Zmm3
+    vaddpd %Zmm4, %Zmm4, %Zmm4
+    vaddpd %Zmm5, %Zmm5, %Zmm5
+    vaddpd %Zmm6, %Zmm6, %Zmm6
+    vaddpd %Zmm7, %Zmm7, %Zmm7
+    vaddpd %Zmm8, %Zmm8, %Zmm8
+    vaddpd %Zmm9, %Zmm9, %Zmm9
+    vaddpd %Zmm10, %Zmm10, %Zmm10
+    vaddpd %Zmm11, %Zmm11, %Zmm11
+    vaddpd %Zmm12, %Zmm12, %Zmm12
+    vaddpd %Zmm13, %Zmm13, %Zmm13
+    vaddpd %Zmm14, %Zmm14, %Zmm14
+    vaddpd %Zmm15, %Zmm15, %Zmm15
 
     subq $1, %rdi
     jg loop10

--- a/src/PPN-microbench/ops.cpp
+++ b/src/PPN-microbench/ops.cpp
@@ -50,10 +50,10 @@ void Ops::run() {
         results[0][i] = wrap(ADD_i32);
 
         // i64
-        results[1][i] = wrap(ADD_f32);
+        results[1][i] = wrap(ADD_i64);
 
         // f32
-        results[2][i] = wrap(ADD_i64);
+        results[2][i] = wrap(ADD_f32);
 
         // f64
         results[3][i] = wrap(ADD_f64);


### PR DESCRIPTION
Removed dependencies by performing operations on different registers.

Also fixed a bug: i64 and f32 function calls were swapped, swapping the results.